### PR TITLE
Update wine to lutris-5.7-10-x86_64

### DIFF
--- a/bw.yml
+++ b/bw.yml
@@ -18,7 +18,7 @@ script:
         arch: win64
     wine:
         dxvk: false
-        version: &wine_version lutris-5.7-8-x86_64
+        version: &wine_version lutris-5.7-10-x86_64
     installer:
     - task:
         description: Creating Wine prefix


### PR DESCRIPTION
https://github.com/lutris/wine/releases/tag/lutris-5.7-10 is latest
supported by lutris

Came across below error while installing (`Failed to retrieve wine (lutris-5.7-8-x86_64) information`), so I updated to lutris-5.7-10 and was able to install successfully.  Thanks.

```
> wget https://raw.githubusercontent.com/balsamiq/balsamiq-wireframes-linux/master/bw.yml -O /tmp/bw.yml && lutris -i /tmp/bw.yml
--2020-10-05 15:24:05--  https://raw.githubusercontent.com/balsamiq/balsamiq-wireframes-linux/master/bw.yml
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 199.232.36.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|199.232.36.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2075 (2.0K) [text/plain]
Saving to: ‘/tmp/bw.yml’

/tmp/bw.yml                   100%[==============================================>]   2.03K  --.-KB/s    in 0s      

2020-10-05 15:24:05 (14.9 MB/s) - ‘/tmp/bw.yml’ saved [2075/2075]

2020-10-05 15:24:06,006: Getting full game list from MAME...
2020-10-05 15:24:06,006: MAME XML generation launched in the background, not returning anything this time
2020-10-05 15:24:06,007: MAME isn't installed, can't retrieve systems list.
2020-10-05 15:24:06,113: Running Lutris 0.5.7.1
2020-10-05 15:24:06,113: Using Intel
2020-10-05 15:24:06,113: Running Mesa driver 20.0.8 on Mesa Intel(R) HD Graphics 530 (SKL GT2) (0x1912)
2020-10-05 15:24:06,114: GPU: 8086:1912 1458:D000 using i915 drivers
2020-10-05 15:24:06,141: Vulkan is supported
2020-10-05 15:24:06,774: MAME XML written
2020-10-05 15:24:15,285: Runner <lutris.runners.wine.wine object at 0x7fc50bb9e8e0> needs to be installed
2020-10-05 15:24:15,297: Getting runner information for wine (version: lutris-5.7-8-x86_64)
2020-10-05 15:24:15,493: Failed to retrieve wine (lutris-5.7-8-x86_64) information
2020-10-05 15:24:15,493: Failed to retrieve wine (lutris-5.7-8-x86_64) information
None
2020-10-05 15:24:23,964: Cancelling installation of Balsamiq Wireframes
2020-10-05 15:24:23,975: No executable found in ['/home/eric/.local/share/lutris/runners/wine/lutris-5.7-8-x86_64/bin/wineserver', '-k']
2020-10-05 15:24:23,976: Non existent path: /home/eric/.cache/lutris/installer/balsamiq-wireframes
2020-10-05 15:31:01,320: MAME XML generation launched in the background, not returning anything this time
2020-10-05 15:31:01,321: Getting full game list from MAME...
2020-10-05 15:31:01,321: MAME isn't installed, can't retrieve systems list.
2020-10-05 15:31:01,415: MAME XML written

```