### PR TITLE
Specify caffe version as shown in bottles, add extra step for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://flatpak.org/setup/
 
 4. download balsamiq wireframes setup.exe, create a new "bottle" with caffe-7.20 runner (different runners have problems) and install it "for all users"
 
-4. in case of graphic problems disable DXVK and VKD3D into bottle preferences
+5. in case of graphic problems disable DXVK and VKD3D into bottle preferences
 
 
 ### PREREQUISITES

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ https://flatpak.org/setup/
 
 2. install bottles from flatpak repo
 
-3. download balsamiq wireframes setup.exe, create a new "bottle" with caffe-72 runner (different runners have problems) and install it "for all users"
+3. download caffe-7.20 from preferences under "runners"
+
+4. download balsamiq wireframes setup.exe, create a new "bottle" with caffe-7.20 runner (different runners have problems) and install it "for all users"
 
 4. in case of graphic problems disable DXVK and VKD3D into bottle preferences
 


### PR DESCRIPTION
"caffe-72" is unclear which version of the runner it is referring to. I found 7.2 on Fedora 37 will not work, and launches with a blank screen. However caffe-7.20 works.

I also added an extra step to make it clear where the runner is obtained from.